### PR TITLE
fix: byLanguageExact typo

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -36,7 +36,7 @@ export const StationSearchType = {
   byState: 'byState',
   byStateExact: 'byStateExact',
   byLanguage: 'byLanguage',
-  byLanguageExact: 'byLanguageexact',
+  byLanguageExact: 'byLanguageExact',
   byTag: 'byTag',
   byTagExact: 'byTagExact'
 } as const


### PR DESCRIPTION
Changed "byLanguageexact" to "byLanguageExact". I think that was a typo.