### PR TITLE
Adding filter search "has_geo_info" parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ const stations = await api.searchStations({
   tagList: ['dance','house']
 })
 
+// query stations with or without geolocation info
+const stations = await api.searchStations({
+  hasGeoInfo: true // not set=display all, true=show only stations with geo_info, false=show only stations without geo_info
+})
+
 //etc..
 ```
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,8 @@ module.exports = {
   testMatch: [
     '<rootDir>/src/**/__tests__/**/*.[jt]s?(x)',
     '<rootDir>/src/**/?(*.)+(spec|test).[jt]s?(x)',
-    '<rootDir>/tests/?(*.)+(spec|test).[jt]s?(x)'
+    '<rootDir>/tests/?(*.)+(spec|test).[jt]s?(x)',
+    '<rootDir>/tests/radioBrowser.test.ts'
   ],
   testEnvironment: 'node',
   watchPlugins: [

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -69,8 +69,8 @@ export type StationResponse = {
   clicktimestamp: string
   clickcount: number
   clicktrend: number
-  geo_lat?: number
-  geo_long?: number
+  geo_lat?: number | null
+  geo_long?: number | null
 }
 
 /**
@@ -101,8 +101,8 @@ export type Station = {
   clickTimestamp: Date
   clickCount: number
   clickTrend: number
-  geoLat?: number
-  geoLong?: number
+  geoLat?: number | null
+  geoLong?: number | null
 }
 
 /**
@@ -136,6 +136,7 @@ export type AdvancedStationQuery = {
   codec?: string
   bitrateMin?: string
   bitrateMax?: string
+  hasGeoInfo?: boolean
 } & StationQuery
 
 /**

--- a/src/radioBrowser.ts
+++ b/src/radioBrowser.ts
@@ -267,8 +267,8 @@ export class RadioBrowserApi {
         lastLocalCheckTime: new Date(response.lastlocalchecktime),
         language: response.language.split(','),
         lastCheckTime: new Date(response.lastchecktime),
-        geoLat: response.geo_lat !== null ? response.geo_lat : undefined,
-        geoLong: response.geo_long !== null ? response.geo_long : undefined,
+        geoLat: response.geo_lat,
+        geoLong: response.geo_long,
         tags: [...new Set(response.tags.split(','))].filter(
           (tag) => tag.length > 0 && tag.length < 10
         ) // drop duplicates and tags over 10 characters
@@ -537,7 +537,9 @@ export class RadioBrowserApi {
     let result = ''
     if (params) {
       for (const [key, value] of Object.entries(params)) {
-        result += `&${key}=${encodeURIComponent(value)}`
+        result += `&${
+          key === 'hasGeoInfo' ? 'has_geo_info' : key
+        }=${encodeURIComponent(value)}`
       }
     }
 

--- a/tests/radioBrowser.test.ts
+++ b/tests/radioBrowser.test.ts
@@ -1,8 +1,7 @@
 import nock from 'nock'
 import nodeFetch from 'node-fetch'
-import { StationQuery } from '../dist/types'
 import { Query } from '../src'
-import { StationSearchType } from '../src/constants'
+import { StationSearchType, StationQuery } from '../src/constants'
 import { RadioBrowserApi } from '../src/radioBrowser'
 import { getMockStation, getMockResponse } from './utils/mockStation'
 
@@ -572,6 +571,90 @@ describe('Radio Browser', () => {
       expect(result).toEqual([getMockStation()])
     })
   })
+  describe('Show or hide stations with geolocation info', () => {
+    // advanced station search
+    test('show stations with geolocation info', async () => {
+      const appName = 'test'
+      const api = new RadioBrowserApi(appName)
+
+      const headerName = 'x-jest-test'
+      const headerValue = '1'
+      const mockResult = [getMockResponse()]
+      const query = {
+        taglist: 'rap,pop,jazz',
+        has_geo_info: 'true'
+      }
+
+      const scope = nock(baseUrl, {
+        reqheaders: {
+          [headerName]: headerValue,
+          'user-agent': appName
+        }
+      })
+        .get('/json/stations/search')
+        .query({
+          hidebroken: 'true',
+          ...query
+        })
+        .reply(200, mockResult)
+
+      const result = await api.searchStations(
+        {
+          tagList: ['rap', 'pop', 'jazz'],
+          hasGeoInfo: true
+        },
+        {
+          headers: {
+            [headerName]: headerValue
+          }
+        }
+      )
+
+      expect(scope.isDone()).toBe(true)
+      expect(result).toEqual([getMockStation()])
+    })
+    test('show stations without geolocation info', async () => {
+      const appName = 'test'
+      const api = new RadioBrowserApi(appName)
+
+      const headerName = 'x-jest-test'
+      const headerValue = '1'
+      const mockResult = [getMockResponse()]
+      const query = {
+        taglist: 'rap,pop,jazz',
+        has_geo_info: 'false'
+      }
+
+      const scope = nock(baseUrl, {
+        reqheaders: {
+          [headerName]: headerValue,
+          'user-agent': appName
+        }
+      })
+        .get('/json/stations/search')
+        .query({
+          hidebroken: 'true',
+          ...query
+        })
+        .reply(200, mockResult)
+
+      const result = await api.searchStations(
+        {
+          tagList: ['rap', 'pop', 'jazz'],
+          hasGeoInfo: false
+        },
+        {
+          headers: {
+            [headerName]: headerValue
+          }
+        }
+      )
+
+      expect(scope.isDone()).toBe(true)
+      expect(result).toEqual([getMockStation()])
+    })
+  })
+
   describe('Show or hide broken stations', () => {
     // advanced station search
     test('hide broken stations by default', async () => {

--- a/tests/utils/mockStation.ts
+++ b/tests/utils/mockStation.ts
@@ -61,3 +61,65 @@ export function getMockStation(): Station {
     geoLong: 14.795494079589846
   }
 }
+
+export function getMockResponseWithoutGeoInfo(): StationResponse {
+  return {
+    changeuuid: '9619b77b-0601-11e8-ae97-52543be04c81',
+    stationuuid: '9619b778-0601-11e8-ae97-52543be04c81',
+    name: 'Radio 021',
+    url: 'http://109.206.96.106:8000/',
+    url_resolved: 'http://109.206.96.106:8000/',
+    homepage: 'http://www.021.rs/',
+    favicon: 'http://www.021.rs/favicon.ico',
+    tags: 'talk,music,news',
+    country: 'Serbia',
+    countrycode: 'RS',
+    state: 'Vojvodina',
+    language: 'serbian,english,german',
+    votes: 44,
+    lastchangetime: '2020-01-19 13:17:10',
+    codec: 'MP3',
+    bitrate: 128,
+    hls: 0,
+    lastcheckok: 1,
+    lastchecktime: '2020-10-27 06:04:51',
+    lastcheckoktime: '2020-10-27 06:04:51',
+    lastlocalchecktime: '2020-10-27 06:04:51',
+    clicktimestamp: '2020-10-25 18:33:05',
+    clickcount: 14,
+    clicktrend: -1,
+    geo_lat: null,
+    geo_long: null
+  }
+}
+
+export function getMockStationWithoutGeoInfo(): Station {
+  return {
+    changeId: '9619b77b-0601-11e8-ae97-52543be04c81',
+    id: '9619b778-0601-11e8-ae97-52543be04c81',
+    name: 'Radio 021',
+    url: 'http://109.206.96.106:8000/',
+    urlResolved: 'http://109.206.96.106:8000/',
+    homepage: 'http://www.021.rs/',
+    favicon: 'http://www.021.rs/favicon.ico',
+    tags: ['talk', 'music', 'news'],
+    country: 'Serbia',
+    countryCode: 'RS',
+    state: 'Vojvodina',
+    language: ['serbian', 'english', 'german'],
+    votes: 44,
+    lastChangeTime: new Date('2020-01-19 13:17:10'),
+    codec: 'MP3',
+    bitrate: 128,
+    hls: Boolean(0),
+    lastCheckOk: Boolean(1),
+    lastCheckTime: new Date('2020-10-27 06:04:51'),
+    lastCheckOkTime: new Date('2020-10-27 06:04:51'),
+    lastLocalCheckTime: new Date('2020-10-27 06:04:51'),
+    clickTimestamp: new Date('2020-10-25 18:33:05'),
+    clickCount: 14,
+    clickTrend: -1,
+    geoLat: null,
+    geoLong: null
+  }
+}


### PR DESCRIPTION
- Added hasGeoInfo in type AdvancedStationsQuery
- Added null as possible value of (_geo_lat_, _geo_long_) and (_geoLat_, _geoLong_) in type _StationResponse_ and _Stations_
- Removed null checking in the normalization of the response.
- Adding special case when area encoding query parameters. 'hasGeoInfo' => 'has_geo_info'
- Adding new tests for check if new search filter _hasGeoInfo_ has a response with stations with and without geolocation info.



