### PR TITLE
Add types to exports in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "exports": {
     "require": "./dist/prod/index.cjs",
     "development": "./dist/dev/index.modern.js",
+    "types": "./dist/types/index.d.ts",
     "default": "./dist/prod/index.modern.js"
   },
   "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
Enables Typescript types to be exported from the package.

Resolves the error below when importing type definitions.  This error also occurs when running `npm run build` 
![image](https://github.com/user-attachments/assets/3fe6a6ac-b7b3-424a-b117-528f6b9ca355)

