### PR TITLE
Use HTTPS for /json/server call

### DIFF
--- a/src/__tests__/radioBrowser.test.ts
+++ b/src/__tests__/radioBrowser.test.ts
@@ -1,12 +1,12 @@
 import nock from 'nock'
 import nodeFetch from 'node-fetch'
 import { Query } from '../../src'
-import { StationSearchType, StationQuery } from '../../src/constants'
+import { StationQuery, StationSearchType } from '../../src/constants'
 import { RadioBrowserApi } from '../../src/radioBrowser'
 import {
-  getMockStation,
   getMockResponse,
   getMockResponseWithoutGeoInfo,
+  getMockStation,
   getMockStationWithoutGeoInfo
 } from './utils/mockStation'
 
@@ -20,7 +20,7 @@ nock.disableNetConnect()
 
 describe('Radio Browser', () => {
   beforeEach(() => {
-    nock('http://all.api.radio-browser.info')
+    nock('https://all.api.radio-browser.info')
       .get('/json/servers')
       .reply(200, [
         {

--- a/src/radioBrowser.ts
+++ b/src/radioBrowser.ts
@@ -1,5 +1,4 @@
 import {
-  StationSearchType,
   AdvancedStationQuery,
   CountryResult,
   CountryStateResult,
@@ -7,6 +6,7 @@ import {
   Station,
   StationQuery,
   StationResponse,
+  StationSearchType,
   TagResult
 } from './constants'
 
@@ -44,16 +44,8 @@ export class RadioBrowserApi {
     config: RequestInit = {}
   ): Promise<{ ip: string; name: string }[]> {
     let result: { ip: string; name: string }[]
-
-    // temporary fix for https cert error when in frontend
-    // hardcode the server
-    // https://github.com/segler-alex/radiobrowser-api-rust/issues/122
-    // if (typeof window !== 'undefined') {
-    //   return [{ ip: '45.77.62.161', name: 'fr1.api.radio-browser.info' }]
-    // }
     const response = await fetch(
-      // this should be https when the above issue is resolved
-      'http://all.api.radio-browser.info/json/servers',
+      'https://all.api.radio-browser.info/json/servers',
       config
     )
     if (response.ok) {


### PR DESCRIPTION
Updates `resolveBaseUrl` to use the HTTPS API url.

Resolves #131